### PR TITLE
Potential fix for code scanning alert no. 8: Cross-site scripting

### DIFF
--- a/src/src/main/java/com/cpaums/service/UpdateService.java
+++ b/src/src/main/java/com/cpaums/service/UpdateService.java
@@ -72,14 +72,8 @@ public class UpdateService {
         
         updateLogRepository.save(log);
         
-        return String.format(
-            "Update logged for user %s: %s -> %s on %s. Success: %s",
-            request.getUserId(),
-            request.getFromVersion(),
-            request.getToVersion(),
-            request.getPlatform(),
-            request.isSuccess()
-        );
+        // Return a generic message that does not include user-provided input
+        return "Update logged";
     }
     
     @Transactional


### PR DESCRIPTION
Potential fix for [https://github.com/abombalemba/CPAUMS/security/code-scanning/8](https://github.com/abombalemba/CPAUMS/security/code-scanning/8)

In general, to fix this type of issue you should avoid returning raw strings that include untrusted input, or you should properly encode/escape the untrusted data according to the context in which it will be rendered. For REST APIs, the best practice is to return structured JSON objects (DTOs) and let the client handle any presentation, rather than sending interpolated, human-readable messages that might be rendered as HTML.

The least intrusive and safest fix here is:

1. Change `UpdateService.logUpdate` to return a structured response object (e.g., containing a boolean success flag and a message), instead of a formatted string created from user input.
2. Update `UpdateController.logUpdate` to return that DTO instead of a plain `String`.

To keep changes local and avoid affecting existing business behavior, we can:

- Introduce a new DTO class `UpdateLogResponseDto` with fields like `boolean success` and `String message`.
- Modify `UpdateService.logUpdate(UpdateLogRequestDto request)` to:
  - Still persist the `UpdateLog` exactly as before.
  - Build a constant or minimally-tainted message that either does not echo user-controlled fields, or only includes data that is known-safe (e.g., enum `platform`, boolean `success`), and wrap it in `UpdateLogResponseDto`.
- Modify `UpdateController.logUpdate` to return `UpdateLogResponseDto` instead of `String`.

However, per the instructions, we are only allowed to edit code in `UpdateController` and `UpdateService` and only within the shown snippets. We also must avoid assuming unshown DTOs. So the smallest safe change that removes the tainted flow is to stop echoing user-controlled fields in the returned value:

- Keep the method signatures the same (`String logUpdate(...)` and `public String logUpdate(...)`) so we don't break callers.
- In `UpdateService.logUpdate`, replace the `String.format` to no longer include any data coming from `request`, and instead return a constant or generic message such as `"Update logged"`. This preserves behavior of writing the log entry to the repository, while changing only the text sent back to clients.
- No changes are needed in `UpdateController` other than still returning the result from the service, but now that result is no longer derived from tainted data.

This way, the logging and persistence behavior is unchanged, but user-controlled data no longer flows to the HTTP response, eliminating the XSS risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
